### PR TITLE
MIDIUSB::sendMidi should write packet, not stream

### DIFF
--- a/src/MIDIUSB.cpp
+++ b/src/MIDIUSB.cpp
@@ -231,5 +231,5 @@ void MIDI_::sendMIDI(midiEventPacket_t event) {
     data[1] = event.byte1;
     data[2] = event.byte2;
     data[3] = event.byte3;
-    write(data, 4);
+    writePacket(data);
 }


### PR DESCRIPTION
With this change, MIDIUSB_write shows the proper note sequence using
````
$ aseqdump -p 20
Waiting for data. Press Ctrl+C to end.
Source  Event                  Ch  Data
 20:0   Note on                 0, note 48, velocity 64
 20:0   Note off                0, note 48, velocity 64
 20:0   Note on                 0, note 48, velocity 64
 20:0   Note off                0, note 48, velocity 64
...
````